### PR TITLE
Support custom group sizes in tournament schedules

### DIFF
--- a/app/Http/Resources/ScheduleSettingsResource.php
+++ b/app/Http/Resources/ScheduleSettingsResource.php
@@ -45,6 +45,9 @@ class ScheduleSettingsResource extends JsonResource
                 'advance_top_n' => $this->resource->groupConfiguration->advance_top_n,
                 'include_best_thirds' => (bool)$this->resource->groupConfiguration->include_best_thirds,
                 'best_thirds_count' => $this->resource->groupConfiguration->best_thirds_count,
+                'group_sizes' => $this->resource->groupConfiguration->group_sizes
+                    ? array_map('intval', $this->resource->groupConfiguration->group_sizes)
+                    : null,
             ] : null,
         ];
     }

--- a/app/Models/TournamentGroupConfiguration.php
+++ b/app/Models/TournamentGroupConfiguration.php
@@ -11,6 +11,7 @@ class TournamentGroupConfiguration extends Model
     protected $fillable = [
         'tournament_id',
         'teams_per_group',
+        'group_sizes',
         'advance_top_n',
         'include_best_thirds',
         'best_thirds_count',
@@ -18,6 +19,7 @@ class TournamentGroupConfiguration extends Model
 
     protected $casts = [
         'include_best_thirds' => 'boolean',
+        'group_sizes' => 'array',
     ];
 
     public function tournament(): BelongsTo

--- a/database/migrations/2025_09_07_000003_add_group_sizes_to_tournament_group_configurations_table.php
+++ b/database/migrations/2025_09_07_000003_add_group_sizes_to_tournament_group_configurations_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('tournament_group_configurations', function (Blueprint $table) {
+            $table->json('group_sizes')->nullable()->after('teams_per_group');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tournament_group_configurations', function (Blueprint $table) {
+            $table->dropColumn('group_sizes');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add a nullable `group_sizes` column to tournament group configurations and cast it on the model
- accept validated custom group size arrays in the schedule request and honour them during group assignment and persistence
- expose configured group sizes via the schedule settings resource and cover 6-6-5/9-8 distributions with feature tests

## Testing
- DB_CONNECTION=sqlite DB_DATABASE=':memory:' ./vendor/bin/pest --filter ScheduleGenerationTest

------
https://chatgpt.com/codex/tasks/task_e_68d01c1f8c848329bcb3026f8da08a9b