### PR TITLE
Agregar servicio de opciones de grupos y exponer sugerencias en ajustes de calendario

### DIFF
--- a/app/Http/Requests/CreateTournamentScheduleRequest.php
+++ b/app/Http/Requests/CreateTournamentScheduleRequest.php
@@ -144,11 +144,11 @@ class CreateTournamentScheduleRequest extends FormRequest
 
             // Configuración de fase de grupos (opcional, solo si group_stage=1)
             'group_phase' => 'nullable|array',
-            'group_phase.option_id' => 'sometimes|string',
+            'group_phase.option_id' => 'sometimes|nullable|string',
             'group_phase.selected_option' => 'sometimes',
             'group_phase.option' => 'sometimes',
-            'group_phase.teams_per_group' => 'required_without:group_phase.option_id|integer|min:2',
-            'group_phase.advance_top_n' => 'required_without:group_phase.option_id|integer|min:1',
+            'group_phase.teams_per_group' => 'nullable|integer|min:2',
+            'group_phase.advance_top_n' => 'nullable|integer|min:1',
             'group_phase.include_best_thirds' => 'sometimes|boolean',
             'group_phase.best_thirds_count' => 'nullable|integer|min:0',
             'group_phase.group_sizes' => 'nullable|array',
@@ -160,36 +160,62 @@ class CreateTournamentScheduleRequest extends FormRequest
     public function withValidator(Validator $validator): void
     {
         $validator->after(function ($validator) {
-            $optionId = $this->input('group_phase.option_id');
+            $groupPhase = $this->input('group_phase');
+
+            if (!is_array($groupPhase)) {
+                return;
+            }
+
+            $optionId = $groupPhase['option_id'] ?? null;
+
             if (!$optionId) {
-                $selectedOption = $this->input('group_phase.selected_option');
+                $selectedOption = $groupPhase['selected_option'] ?? null;
                 if (is_array($selectedOption)) {
                     $optionId = $selectedOption['id'] ?? null;
                 } elseif (is_string($selectedOption)) {
                     $optionId = $selectedOption;
                 }
             }
+
             if (!$optionId) {
-                $option = $this->input('group_phase.option');
+                $option = $groupPhase['option'] ?? null;
                 if (is_string($option)) {
                     $optionId = $option;
                 }
             }
 
-            if ($optionId) {
-                return;
-            }
-
-            $groupSizes = $this->input('group_phase.group_sizes');
-            if (is_array($groupSizes) && count($groupSizes) > 0) {
-                $totalTeams = (int)$this->input('general.total_teams');
-                $configuredTotal = array_sum(array_map('intval', $groupSizes));
-
-                if ($configuredTotal !== $totalTeams) {
+            if (!$optionId) {
+                if (!array_key_exists('teams_per_group', $groupPhase)
+                    || $groupPhase['teams_per_group'] === null
+                    || $groupPhase['teams_per_group'] === ''
+                ) {
                     $validator->errors()->add(
-                        'group_phase.group_sizes',
-                        'La suma de los tamaños de grupo debe coincidir con el total de equipos (' . $totalTeams . ').'
+                        'group_phase.teams_per_group',
+                        'El campo group phase.teams per group es obligatorio cuando no se selecciona una opción predefinida.'
                     );
+                }
+
+                if (!array_key_exists('advance_top_n', $groupPhase)
+                    || $groupPhase['advance_top_n'] === null
+                    || $groupPhase['advance_top_n'] === ''
+                ) {
+                    $validator->errors()->add(
+                        'group_phase.advance_top_n',
+                        'El campo group phase.advance top n es obligatorio cuando no se selecciona una opción predefinida.'
+                    );
+                }
+
+                $groupSizes = $groupPhase['group_sizes'] ?? null;
+                if (is_array($groupSizes) && count($groupSizes) > 0) {
+                    $totalTeams = (int)$this->input('general.total_teams');
+                    $configuredTotal = array_sum(array_map('intval', $groupSizes));
+
+                    if ($configuredTotal !== $totalTeams) {
+                        $validator->errors()->add(
+                            'group_phase.group_sizes',
+                            'La suma de los tamaños de grupo debe coincidir con el total de equipos (' . $totalTeams . ').'
+                        );
+                    }
                 }
             }
         });

--- a/app/Services/GroupConfigurationOptionService.php
+++ b/app/Services/GroupConfigurationOptionService.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace App\Services;
+
+class GroupConfigurationOptionService
+{
+    private const MIN_GROUP_SIZE = 3;
+    private const MAX_GROUP_SIZE = 6;
+    private const MIN_GROUPS = 2;
+    private const MAX_TOTAL_TEAMS = 36;
+
+    private const ELIMINATION_STAGES = [
+        [
+            'teams' => 4,
+            'label' => 'Semifinal',
+            'phase_name' => 'Semifinales',
+        ],
+        [
+            'teams' => 8,
+            'label' => 'Cuartos',
+            'phase_name' => 'Cuartos de Final',
+        ],
+        [
+            'teams' => 16,
+            'label' => 'Octavos',
+            'phase_name' => 'Octavos de Final',
+        ],
+        [
+            'teams' => 32,
+            'label' => 'Dieciseisavos',
+            'phase_name' => 'Dieciseisavos de Final',
+        ],
+    ];
+
+    /**
+     * Genera todas las opciones de configuración de grupos válidas para un total de equipos.
+     */
+    public function buildOptions(int $totalTeams): array
+    {
+        if ($totalTeams < self::MIN_GROUP_SIZE * self::MIN_GROUPS || $totalTeams > self::MAX_TOTAL_TEAMS) {
+            return [];
+        }
+
+        $combinations = [];
+        $this->generateCombinations($totalTeams, self::MAX_GROUP_SIZE, [], $combinations);
+
+        $options = [];
+        foreach ($combinations as $groupSizes) {
+            $option = $this->buildOptionPayload($groupSizes);
+            if ($option !== null) {
+                $options[] = $option;
+            }
+        }
+
+        usort($options, function (array $a, array $b) {
+            $countComparison = count($a['group_sizes']) <=> count($b['group_sizes']);
+            if ($countComparison !== 0) {
+                return $countComparison;
+            }
+
+            $sizesA = $a['group_sizes'];
+            $sizesB = $b['group_sizes'];
+            $length = min(count($sizesA), count($sizesB));
+            for ($i = 0; $i < $length; $i++) {
+                if ($sizesA[$i] === $sizesB[$i]) {
+                    continue;
+                }
+
+                // ordenar de mayor a menor dentro del mismo número de grupos
+                return $sizesB[$i] <=> $sizesA[$i];
+            }
+
+            return count($sizesA) <=> count($sizesB);
+        });
+
+        return $options;
+    }
+
+    private function generateCombinations(int $remaining, int $maxSize, array $current, array &$results): void
+    {
+        if ($remaining === 0) {
+            if (count($current) >= self::MIN_GROUPS) {
+                $results[] = $current;
+            }
+            return;
+        }
+
+        $upper = min($maxSize, self::MAX_GROUP_SIZE, $remaining);
+        for ($size = $upper; $size >= self::MIN_GROUP_SIZE; $size--) {
+            if ($size > $remaining) {
+                continue;
+            }
+
+            $nextRemaining = $remaining - $size;
+            if ($nextRemaining > 0 && $nextRemaining < self::MIN_GROUP_SIZE) {
+                continue;
+            }
+
+            $current[] = $size;
+            $this->generateCombinations($nextRemaining, $size, $current, $results);
+            array_pop($current);
+        }
+    }
+
+    private function buildOptionPayload(array $groupSizes): ?array
+    {
+        rsort($groupSizes, SORT_NUMERIC);
+        $groups = count($groupSizes);
+        $advanceTopN = 2;
+        $baseQualifiers = $groups * $advanceTopN;
+
+        $stage = $this->resolveStage($groups, $baseQualifiers);
+        if ($stage === null) {
+            return null;
+        }
+
+        $neededBestThirds = $stage['teams'] - $baseQualifiers;
+        if ($neededBestThirds < 0 || $neededBestThirds > $groups) {
+            return null;
+        }
+
+        $includeBestThirds = $neededBestThirds > 0;
+
+        $groupPhasePayload = [
+            'teams_per_group' => max($groupSizes),
+            'advance_top_n' => $advanceTopN,
+            'include_best_thirds' => $includeBestThirds,
+            'best_thirds_count' => $includeBestThirds ? $neededBestThirds : null,
+            'group_sizes' => $groupSizes,
+        ];
+
+        return [
+            'id' => $this->buildOptionId($groupSizes, $stage['teams']),
+            'groups' => $groups,
+            'group_sizes' => $groupSizes,
+            'group_phase' => $groupPhasePayload,
+            'elimination' => [
+                'teams' => $stage['teams'],
+                'label' => $stage['label'],
+                'phase_name' => $stage['phase_name'],
+            ],
+        ];
+    }
+
+    private function resolveStage(int $groups, int $baseQualifiers): ?array
+    {
+        foreach (self::ELIMINATION_STAGES as $stage) {
+            if ($baseQualifiers > $stage['teams']) {
+                continue;
+            }
+
+            $needed = $stage['teams'] - $baseQualifiers;
+            if ($needed === 0 || $needed <= $groups) {
+                return $stage;
+            }
+        }
+
+        return null;
+    }
+
+    private function buildOptionId(array $groupSizes, int $stageTeams): string
+    {
+        return implode('-', $groupSizes) . '|' . $stageTeams;
+    }
+}

--- a/tests/Feature/ScheduleSettingsGroupOptionsTest.php
+++ b/tests/Feature/ScheduleSettingsGroupOptionsTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use App\Models\Phase;
+use App\Services\GroupConfigurationOptionService;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Carbon;
+
+it('exposes suggested group configuration options for odd totals', function (
+    int $totalTeams,
+    array $expectedSizes,
+    string $expectedStage,
+    bool $includeBestThirds,
+    ?int $bestThirdsCount
+) {
+    [$tournament, $location] = createTournamentViaApi(TournamentFormatId::GroupAndElimination->value, 1, null, null);
+    attachTeamsToTournament($tournament, $totalTeams);
+
+    $response = $this->getJson("/api/v1/admin/tournaments/{$tournament->id}/schedule/settings")
+        ->assertOk()
+        ->json();
+
+    $options = collect($response['group_configuration_options']);
+    expect($options)->not->toBeEmpty();
+
+    $option = $options->first(fn (array $opt) => $opt['group_sizes'] === $expectedSizes);
+    expect($option)->not->toBeNull();
+    expect($option['elimination']['label'])->toBe($expectedStage);
+    expect($option['group_phase']['include_best_thirds'])->toBe($includeBestThirds);
+    if ($includeBestThirds) {
+        expect($option['group_phase']['best_thirds_count'])->toBe($bestThirdsCount);
+    } else {
+        expect($option['group_phase']['best_thirds_count'])->toBeNull();
+    }
+})->with([
+    '17 equipos' => [17, [6, 6, 5], 'Cuartos', true, 2],
+    '21 equipos' => [21, [6, 5, 5, 5], 'Cuartos', false, null],
+    '35 equipos' => [35, [6, 6, 6, 6, 6, 5], 'Octavos', true, 4],
+]);
+
+it('persists group configuration when selecting a precomputed option', function () {
+    [$tournament, $location] = createTournamentViaApi(TournamentFormatId::GroupAndElimination->value, 1, null, null);
+    attachTeamsToTournament($tournament, 17);
+    $field = $location->fields()->first();
+    $startDate = Carbon::now()->next(CarbonInterface::FRIDAY)->startOfDay()->toIso8601String();
+
+    $service = new GroupConfigurationOptionService();
+    $option = collect($service->buildOptions(17))
+        ->first(fn (array $opt) => $opt['group_sizes'] === [6, 6, 5]);
+    expect($option)->not->toBeNull();
+
+    $phases = Phase::whereIn('name', ['Fase de grupos', 'Octavos de Final', 'Cuartos de Final', 'Semifinales', 'Final'])
+        ->get()
+        ->keyBy('name');
+
+    $payload = [
+        'general' => [
+            'tournament_id' => $tournament->id,
+            'tournament_format_id' => TournamentFormatId::GroupAndElimination->value,
+            'football_type_id' => 1,
+            'start_date' => $startDate,
+            'game_time' => 90,
+            'time_between_games' => 0,
+            'total_teams' => 17,
+            'round_trip' => false,
+            'group_stage' => true,
+            'elimination_round_trip' => true,
+            'locations' => [['id' => $location->id, 'name' => $location->name]],
+        ],
+        'rules_phase' => [
+            'round_trip' => false,
+            'tiebreakers' => $tournament->configuration->tiebreakers->toArray(),
+        ],
+        'group_phase' => [
+            'option_id' => $option['id'],
+        ],
+        'elimination_phase' => [
+            'teams_to_next_round' => 8,
+            'elimination_round_trip' => true,
+            'phases' => [
+                ['id' => $phases['Fase de grupos']->id, 'name' => 'Fase de grupos', 'is_active' => true, 'is_completed' => false, 'tournament_id' => $tournament->id],
+                ['id' => $phases['Octavos de Final']->id, 'name' => 'Octavos de Final', 'is_active' => false, 'is_completed' => false, 'tournament_id' => $tournament->id],
+                ['id' => $phases['Cuartos de Final']->id, 'name' => 'Cuartos de Final', 'is_active' => false, 'is_completed' => false, 'tournament_id' => $tournament->id],
+                ['id' => $phases['Semifinales']->id, 'name' => 'Semifinales', 'is_active' => false, 'is_completed' => false, 'tournament_id' => $tournament->id],
+                ['id' => $phases['Final']->id, 'name' => 'Final', 'is_active' => false, 'is_completed' => false, 'tournament_id' => $tournament->id],
+            ],
+        ],
+        'fields_phase' => [[
+            'field_id' => $field->id,
+            'step' => 1,
+            'field_name' => $field->name,
+            'location_id' => $location->id,
+            'location_name' => $location->name,
+            'disabled' => false,
+            'availability' => [
+                'friday' => [
+                    'enabled' => true,
+                    'available_range' => '09:00 a 17:00',
+                    'intervals' => [
+                        ['value' => '09:00', 'text' => '09:00', 'selected' => true, 'disabled' => false],
+                        ['value' => '11:00', 'text' => '11:00', 'selected' => true, 'disabled' => false],
+                        ['value' => '13:00', 'text' => '13:00', 'selected' => true, 'disabled' => false],
+                        ['value' => '15:00', 'text' => '15:00', 'selected' => true, 'disabled' => false],
+                    ],
+                    'label' => 'Viernes',
+                ],
+                'saturday' => [
+                    'enabled' => true,
+                    'available_range' => '09:00 a 17:00',
+                    'intervals' => [
+                        ['value' => '09:00', 'text' => '09:00', 'selected' => true, 'disabled' => false],
+                        ['value' => '11:00', 'text' => '11:00', 'selected' => true, 'disabled' => false],
+                        ['value' => '13:00', 'text' => '13:00', 'selected' => true, 'disabled' => false],
+                        ['value' => '15:00', 'text' => '15:00', 'selected' => true, 'disabled' => false],
+                    ],
+                    'label' => 'Sábado',
+                ],
+                'isCompleted' => true,
+            ],
+        ]],
+    ];
+
+    $this->postJson("/api/v1/admin/tournaments/{$tournament->id}/schedule", $payload)
+        ->assertOk();
+
+    $config = $tournament->fresh()->groupConfiguration;
+    expect($config->teams_per_group)->toBe(6);
+    expect($config->advance_top_n)->toBe(2);
+    expect($config->include_best_thirds)->toBeTrue();
+    expect($config->best_thirds_count)->toBe(2);
+    expect($config->group_sizes)->toBe([6, 6, 5]);
+
+    $settings = $this->getJson("/api/v1/admin/tournaments/{$tournament->id}/schedule/settings")
+        ->assertOk()
+        ->json();
+
+    expect($settings['group_phase_option_id'])->toBe($option['id']);
+});

--- a/tests/Unit/GroupConfigurationOptionServiceTest.php
+++ b/tests/Unit/GroupConfigurationOptionServiceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Services\GroupConfigurationOptionService;
+
+it('builds expected group configuration options for odd totals', function (
+    int $totalTeams,
+    array $expectedSizes,
+    int $advanceTopN,
+    bool $includeBestThirds,
+    ?int $bestThirdsCount,
+    string $expectedStage
+) {
+    $service = new GroupConfigurationOptionService();
+    $options = collect($service->buildOptions($totalTeams));
+
+    expect($options)->not->toBeEmpty();
+
+    $option = $options->first(fn (array $opt) => $opt['group_sizes'] === $expectedSizes);
+    expect($option)->not->toBeNull();
+
+    expect($option['group_phase']['advance_top_n'])->toBe($advanceTopN);
+    expect($option['group_phase']['include_best_thirds'])->toBe($includeBestThirds);
+    if ($includeBestThirds) {
+        expect($option['group_phase']['best_thirds_count'])->toBe($bestThirdsCount);
+    } else {
+        expect($option['group_phase']['best_thirds_count'])->toBeNull();
+    }
+    expect($option['elimination']['label'])->toBe($expectedStage);
+})->with([
+    '17 equipos (6-6-5)' => [17, [6, 6, 5], 2, true, 2, 'Cuartos'],
+    '21 equipos (6-5-5-5)' => [21, [6, 5, 5, 5], 2, false, null, 'Cuartos'],
+    '35 equipos (6-6-6-6-6-5)' => [35, [6, 6, 6, 6, 6, 5], 2, true, 4, 'Octavos'],
+]);


### PR DESCRIPTION
## Resumen
- crear `GroupConfigurationOptionService` para generar combinaciones válidas de tamaños de grupo, cupos de clasificación y fase eliminatoria sugerida
- exponer las opciones calculadas y la opción seleccionada en `ScheduleSettingsResource`, además de ajustar la request y el guardado para aceptar `option_id`
- añadir pruebas unitarias y de feature que cubren el servicio y el endpoint con totales impares representativos

## Pruebas
- `vendor/bin/pest` *(falla: conexión MySQL rechazada en el entorno de pruebas)*

------
https://chatgpt.com/codex/tasks/task_e_68d04ef927c883299b33ace7057cd82e