### PR TITLE
Tighten group phase schedule validation rules

### DIFF
--- a/app/Http/Requests/CreateTournamentScheduleRequest.php
+++ b/app/Http/Requests/CreateTournamentScheduleRequest.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
+use TournamentFormatId;
 
 class CreateTournamentScheduleRequest extends FormRequest
 {
@@ -17,6 +18,7 @@ class CreateTournamentScheduleRequest extends FormRequest
     public function rules(): array
     {
         $tournamentId = $this->input('general.tournament_id');
+        $formatId = (int) $this->input('general.tournament_format_id');
 
         $config = DB::table('tournament_configurations')
             ->where('tournament_id', $tournamentId)
@@ -24,6 +26,10 @@ class CreateTournamentScheduleRequest extends FormRequest
 
         $minTeams = $config->min_teams ?? 8;
         $maxTeams = $config->max_teams ?? 40;
+
+        if ($formatId === TournamentFormatId::GroupAndElimination->value) {
+            $maxTeams = min($maxTeams, 36);
+        }
         return [
             // Validación de "general"
             'general' => 'required|array',
@@ -49,12 +55,12 @@ class CreateTournamentScheduleRequest extends FormRequest
                 'required',
                 'integer',
                 'exists:locations,id',
-                Rule::exists('location_tournament', 'location_id')->where(function ($query) {
-                    return $query->where('tournament_id', request('general.tournament_id'));
+                Rule::exists('location_tournament', 'location_id')->where(function ($query) use ($tournamentId) {
+                    return $query->where('tournament_id', $tournamentId);
                 }),
-                Rule::exists('league_location', 'location_id')->where(function ($query) {
-                    return $query->whereIn('league_id', function ($subQuery) {
-                        $subQuery->select('league_id')->from('tournaments')->where('id', request('general.tournament_id'));
+                Rule::exists('league_location', 'location_id')->where(function ($query) use ($tournamentId) {
+                    return $query->whereIn('league_id', function ($subQuery) use ($tournamentId) {
+                        $subQuery->select('league_id')->from('tournaments')->where('id', $tournamentId);
                     });
                 }),
             ],
@@ -149,7 +155,7 @@ class CreateTournamentScheduleRequest extends FormRequest
             'group_phase.include_best_thirds' => 'sometimes|boolean',
             'group_phase.best_thirds_count' => 'nullable|integer|min:0',
             'group_phase.group_sizes' => 'nullable|array',
-            'group_phase.group_sizes.*' => 'integer|min:2',
+            'group_phase.group_sizes.*' => 'integer|min:3|max:6',
 
         ];
     }
@@ -159,8 +165,9 @@ class CreateTournamentScheduleRequest extends FormRequest
         $validator->after(function ($validator) {
             $groupSizes = $this->input('group_phase.group_sizes');
             if (is_array($groupSizes) && count($groupSizes) > 0) {
-                $totalTeams = (int)$this->input('general.total_teams');
-                $configuredTotal = array_sum(array_map('intval', $groupSizes));
+                $totalTeams = (int) $this->input('general.total_teams');
+                $configuredSizes = array_values(array_map('intval', $groupSizes));
+                $configuredTotal = array_sum($configuredSizes);
 
                 if ($configuredTotal !== $totalTeams) {
                     $validator->errors()->add(
@@ -168,6 +175,27 @@ class CreateTournamentScheduleRequest extends FormRequest
                         'La suma de los tamaños de grupo debe coincidir con el total de equipos (' . $totalTeams . ').'
                     );
                 }
+
+                if (count($configuredSizes) === 1 && $configuredSizes[0] === $totalTeams) {
+                    $validator->errors()->add(
+                        'group_phase.group_sizes',
+                        'Debe configurar al menos dos grupos distintos para la fase de grupos.'
+                    );
+                }
+            }
+
+            $formatId = (int) $this->input('general.tournament_format_id');
+            $totalTeams = (int) $this->input('general.total_teams');
+
+            if (
+                $formatId === TournamentFormatId::GroupAndElimination->value
+                && $totalTeams % 2 === 1
+                && $totalTeams > 36
+            ) {
+                $validator->errors()->add(
+                    'general.total_teams',
+                    'Los torneos con fase de grupos admiten un máximo de 36 equipos cuando el total es impar.'
+                );
             }
         });
     }

--- a/app/Http/Requests/CreateTournamentScheduleRequest.php
+++ b/app/Http/Requests/CreateTournamentScheduleRequest.php
@@ -163,7 +163,24 @@ class CreateTournamentScheduleRequest extends FormRequest
     public function withValidator(Validator $validator): void
     {
         $validator->after(function ($validator) {
-            $groupSizes = $this->input('group_phase.group_sizes');
+            $groupPhase = $this->input('group_phase');
+
+            if (is_array($groupPhase)) {
+                if (!array_key_exists('advance_top_n', $groupPhase)
+                    || $groupPhase['advance_top_n'] === null
+                    || $groupPhase['advance_top_n'] === ''
+                ) {
+                    $validator->errors()->add(
+                        'group_phase.advance_top_n',
+                        'El campo group phase.advance top n es obligatorio cuando no se selecciona una opción predefinida.'
+                    );
+                }
+            }
+
+            $groupSizes = is_array($groupPhase)
+                ? ($groupPhase['group_sizes'] ?? null)
+                : $this->input('group_phase.group_sizes');
+
             if (is_array($groupSizes) && count($groupSizes) > 0) {
                 $totalTeams = (int) $this->input('general.total_teams');
                 $configuredSizes = array_values(array_map('intval', $groupSizes));

--- a/app/Http/Requests/CreateTournamentScheduleRequest.php
+++ b/app/Http/Requests/CreateTournamentScheduleRequest.php
@@ -150,8 +150,11 @@ class CreateTournamentScheduleRequest extends FormRequest
 
             // Configuración de fase de grupos (opcional, solo si group_stage=1)
             'group_phase' => 'nullable|array',
-            'group_phase.teams_per_group' => 'required_with:group_phase|integer|min:2',
-            'group_phase.advance_top_n' => 'required_with:group_phase|integer|min:1',
+            'group_phase.option_id' => 'sometimes|nullable|string',
+            'group_phase.selected_option' => 'sometimes',
+            'group_phase.option' => 'sometimes',
+            'group_phase.teams_per_group' => 'nullable|integer|min:2',
+            'group_phase.advance_top_n' => 'nullable|integer|min:1',
             'group_phase.include_best_thirds' => 'sometimes|boolean',
             'group_phase.best_thirds_count' => 'nullable|integer|min:0',
             'group_phase.group_sizes' => 'nullable|array',
@@ -166,14 +169,44 @@ class CreateTournamentScheduleRequest extends FormRequest
             $groupPhase = $this->input('group_phase');
 
             if (is_array($groupPhase)) {
-                if (!array_key_exists('advance_top_n', $groupPhase)
-                    || $groupPhase['advance_top_n'] === null
-                    || $groupPhase['advance_top_n'] === ''
-                ) {
-                    $validator->errors()->add(
-                        'group_phase.advance_top_n',
-                        'El campo group phase.advance top n es obligatorio cuando no se selecciona una opción predefinida.'
-                    );
+                $optionId = $groupPhase['option_id'] ?? null;
+
+                if ($optionId === null || $optionId === '') {
+                    $selectedOption = $groupPhase['selected_option'] ?? null;
+                    if (is_array($selectedOption)) {
+                        $optionId = $selectedOption['id'] ?? null;
+                    } elseif (is_string($selectedOption) || is_int($selectedOption)) {
+                        $optionId = $selectedOption;
+                    }
+                }
+
+                if ($optionId === null || $optionId === '') {
+                    $option = $groupPhase['option'] ?? null;
+                    if (is_string($option) || is_int($option)) {
+                        $optionId = $option;
+                    }
+                }
+
+                if ($optionId === null || $optionId === '') {
+                    if (!array_key_exists('teams_per_group', $groupPhase)
+                        || $groupPhase['teams_per_group'] === null
+                        || $groupPhase['teams_per_group'] === ''
+                    ) {
+                        $validator->errors()->add(
+                            'group_phase.teams_per_group',
+                            'El campo group phase.teams per group es obligatorio cuando no se selecciona una opción predefinida.'
+                        );
+                    }
+
+                    if (!array_key_exists('advance_top_n', $groupPhase)
+                        || $groupPhase['advance_top_n'] === null
+                        || $groupPhase['advance_top_n'] === ''
+                    ) {
+                        $validator->errors()->add(
+                            'group_phase.advance_top_n',
+                            'El campo group phase.advance top n es obligatorio cuando no se selecciona una opción predefinida.'
+                        );
+                    }
                 }
             }
 

--- a/config/constants.php
+++ b/config/constants.php
@@ -256,7 +256,7 @@ return [
         [
             'tournament_format_id' => TournamentFormatId::GroupAndElimination->value,
             'football_type_id' => FootballTypeId::TraditionalFootball->value,
-            'max_teams' => 32,
+            'max_teams' => 36,
             'min_teams' => 8,
             'substitutions_per_team' => 5,
             'max_players_per_team' => 23,
@@ -271,7 +271,7 @@ return [
         [
             'tournament_format_id' => TournamentFormatId::GroupAndElimination->value,
             'football_type_id' => FootballTypeId::SevenFootball->value, // Fútbol 7
-            'max_teams' => 16,
+            'max_teams' => 36,
             'min_teams' => 8,
             'substitutions_per_team' => -1,
             'max_players_per_team' => 18,
@@ -286,7 +286,7 @@ return [
         [
             'tournament_format_id' => TournamentFormatId::GroupAndElimination->value,
             'football_type_id' => FootballTypeId::Futsal->value,
-            'max_teams' => 16,
+            'max_teams' => 36,
             'min_teams' => 8,
             'substitutions_per_team' => -1,
             'max_players_per_team' => 15,

--- a/database/migrations/2025_09_15_000000_update_group_and_elimination_max_teams.php
+++ b/database/migrations/2025_09_15_000000_update_group_and_elimination_max_teams.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        $groupAndElimination = 3;
+
+        DB::table('default_tournament_configurations')
+            ->where('tournament_format_id', $groupAndElimination)
+            ->update(['max_teams' => 36]);
+
+        DB::table('tournament_configurations')
+            ->where('tournament_format_id', $groupAndElimination)
+            ->update(['max_teams' => 36]);
+    }
+
+    public function down(): void
+    {
+        $groupAndElimination = 3;
+        $traditionalFootball = 1;
+        $sevenFootball = 2;
+        $futsal = 3;
+
+        DB::table('default_tournament_configurations')
+            ->where('tournament_format_id', $groupAndElimination)
+            ->where('football_type_id', $traditionalFootball)
+            ->update(['max_teams' => 32]);
+
+        DB::table('default_tournament_configurations')
+            ->where('tournament_format_id', $groupAndElimination)
+            ->whereIn('football_type_id', [
+                $sevenFootball,
+                $futsal,
+            ])
+            ->update(['max_teams' => 16]);
+
+        DB::table('tournament_configurations')
+            ->where('tournament_format_id', $groupAndElimination)
+            ->where('football_type_id', $traditionalFootball)
+            ->update(['max_teams' => 32]);
+
+        DB::table('tournament_configurations')
+            ->where('tournament_format_id', $groupAndElimination)
+            ->whereIn('football_type_id', [
+                $sevenFootball,
+                $futsal,
+            ])
+            ->update(['max_teams' => 16]);
+    }
+};

--- a/tests/Feature/TournamentScheduleValidationTest.php
+++ b/tests/Feature/TournamentScheduleValidationTest.php
@@ -1,0 +1,157 @@
+<?php
+
+use App\Http\Requests\CreateTournamentScheduleRequest;
+use App\Models\Tournament;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Validator;
+
+function buildGroupSchedulePayload(Tournament $tournament, array $groupSizes, ?int $totalTeams = null, ?int $teamsPerGroup = null): array
+{
+    $tournament->loadMissing(['configuration.tiebreakers', 'tournamentPhases.phase', 'locations.fields']);
+
+    $location = $tournament->locations->first();
+    $field = $location->fields->first();
+    $totalTeams ??= array_sum($groupSizes);
+    $teamsPerGroup ??= $groupSizes[0] ?? 3;
+
+    $tiebreakers = $tournament->configuration->tiebreakers->map(static function ($tiebreaker) {
+        return [
+            'id' => $tiebreaker->id,
+            'rule' => $tiebreaker->rule,
+            'priority' => $tiebreaker->priority,
+            'is_active' => (bool) $tiebreaker->is_active,
+            'tournament_configuration_id' => $tiebreaker->tournament_configuration_id,
+        ];
+    })->values()->all();
+
+    $phases = $tournament->tournamentPhases->map(static function ($phase) use ($tournament) {
+        return [
+            'tournament_id' => $tournament->id,
+            'id' => $phase->phase->id,
+            'name' => $phase->phase->name,
+            'is_active' => (bool) $phase->is_active,
+            'is_completed' => (bool) $phase->is_completed,
+        ];
+    })->values()->all();
+
+    return [
+        'general' => [
+            'tournament_id' => $tournament->id,
+            'tournament_format_id' => $tournament->tournament_format_id,
+            'football_type_id' => $tournament->football_type_id,
+            'start_date' => Carbon::now()->addDay()->toDateString(),
+            'game_time' => 90,
+            'time_between_games' => 0,
+            'total_teams' => $totalTeams,
+            'locations' => [
+                [
+                    'id' => $location->id,
+                    'name' => $location->name,
+                ],
+            ],
+        ],
+        'rules_phase' => [
+            'round_trip' => false,
+            'tiebreakers' => $tiebreakers,
+        ],
+        'elimination_phase' => [
+            'teams_to_next_round' => 8,
+            'elimination_round_trip' => false,
+            'phases' => $phases,
+        ],
+        'fields_phase' => [
+            [
+                'field_id' => $field->id,
+                'step' => 1,
+                'field_name' => $field->name,
+                'location_name' => $location->name,
+                'location_id' => $location->id,
+                'disabled' => false,
+                'availability' => [
+                    'friday' => [
+                        'enabled' => true,
+                        'available_range' => '09:00 a 17:00',
+                        'intervals' => [
+                            ['value' => '09:00', 'text' => '09:00', 'selected' => true, 'disabled' => false, 'in_use' => false],
+                            ['value' => '10:00', 'text' => '10:00', 'selected' => false, 'disabled' => false, 'in_use' => false],
+                        ],
+                        'label' => 'Viernes',
+                    ],
+                    'isCompleted' => true,
+                ],
+            ],
+        ],
+        'group_phase' => [
+            'teams_per_group' => $teamsPerGroup,
+            'advance_top_n' => 2,
+            'include_best_thirds' => false,
+            'best_thirds_count' => 0,
+            'group_sizes' => $groupSizes,
+        ],
+    ];
+}
+
+function validateSchedulePayload(array $payload): \Illuminate\Contracts\Validation\Validator
+{
+    $request = CreateTournamentScheduleRequest::create('/api/v1/admin/tournaments/schedule', 'POST', $payload);
+    $request->setContainer(app())->setRedirector(app('redirect'));
+
+    $validator = Validator::make($request->all(), $request->rules());
+    $request->withValidator($validator);
+
+    return $validator;
+}
+
+it('rechaza tamaños de grupo menores a tres', function () {
+    [$tournament] = createTournamentViaApi(TournamentFormatId::GroupAndElimination->value, 1, null, null);
+
+    $payload = buildGroupSchedulePayload($tournament, [2, 2, 2, 2, 2, 2], 12, 2);
+
+    $validator = validateSchedulePayload($payload);
+
+    expect($validator->fails())->toBeTrue();
+    expect($validator->errors()->has('group_phase.group_sizes.0'))->toBeTrue();
+});
+
+it('rechaza tamaños de grupo mayores a seis', function () {
+    [$tournament] = createTournamentViaApi(TournamentFormatId::GroupAndElimination->value, 1, null, null);
+
+    $payload = buildGroupSchedulePayload($tournament, [7, 7, 7, 7, 7], 35, 7);
+
+    $validator = validateSchedulePayload($payload);
+
+    expect($validator->fails())->toBeTrue();
+    expect($validator->errors()->has('group_phase.group_sizes.0'))->toBeTrue();
+});
+
+it('rechaza configurar un único grupo con todos los equipos', function () {
+    [$tournament] = createTournamentViaApi(TournamentFormatId::GroupAndElimination->value, 1, null, null);
+
+    $payload = buildGroupSchedulePayload($tournament, [12], 12, 12);
+
+    $validator = validateSchedulePayload($payload);
+
+    expect($validator->fails())->toBeTrue();
+    expect($validator->errors()->has('group_phase.group_sizes'))->toBeTrue();
+});
+
+it('rechaza totales mayores a treinta y seis equipos', function () {
+    [$tournament] = createTournamentViaApi(TournamentFormatId::GroupAndElimination->value, 1, null, null);
+
+    $payload = buildGroupSchedulePayload($tournament, [6, 6, 6, 6, 6, 4, 3], 37, 6);
+
+    $validator = validateSchedulePayload($payload);
+
+    expect($validator->fails())->toBeTrue();
+    expect($validator->errors()->has('general.total_teams'))->toBeTrue();
+});
+
+it('acepta configuraciones válidas dentro de los límites', function () {
+    [$tournament] = createTournamentViaApi(TournamentFormatId::GroupAndElimination->value, 1, null, null);
+
+    $payload = buildGroupSchedulePayload($tournament, [6, 6, 6, 6, 6, 6], 36, 6);
+
+    $validator = validateSchedulePayload($payload);
+
+    expect($validator->passes())->toBeTrue();
+});

--- a/tests/Feature/TournamentTest.php
+++ b/tests/Feature/TournamentTest.php
@@ -93,7 +93,7 @@ it('store tournament', function () {
             'category_id' => $category->first()->id,
             'start_date' => fake()->date(),
             'end_date' => fake()->date(),
-            'min_max' => json_encode([18, 32], JSON_THROW_ON_ERROR | true),
+            'min_max' => json_encode([18, 36], JSON_THROW_ON_ERROR | true),
         ],
         'details' => [
             'prize' => fake()->text(10),
@@ -150,7 +150,7 @@ it('update tournaments with filters and location', function () {
             'name' => fake()->name,
             'tournament_format_id' => $tournament->format->id,
             'category_id' => $tournament->category->id,
-            'min_max' => json_encode([18, 32], JSON_THROW_ON_ERROR | true),
+            'min_max' => json_encode([18, 36], JSON_THROW_ON_ERROR | true),
         ],
         'details' => [
             'start_date' => fake()->date('Y-m-d'),
@@ -188,7 +188,7 @@ it('get tournaments with filters and location without autocomplete', function ()
             'name' => fake()->name,
             'tournament_format_id' => $tournament->format->id,
             'category_id' => $tournament->category->id,
-            'min_max' => json_encode([18, 32], JSON_THROW_ON_ERROR | true),
+            'min_max' => json_encode([18, 36], JSON_THROW_ON_ERROR | true),
         ],
         'details' => [
             'start_date' => fake()->date('Y-m-d'),

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -98,7 +98,7 @@ function createTournamentViaApi(int $formatId = TournamentFormatId::League->valu
             'category_id' => $category->id,
             'start_date' => now()->addDays(3)->format('Y-m-d'),
             'end_date' => now()->addDays(30)->format('Y-m-d'),
-            'min_max' => json_encode([8, 32], JSON_THROW_ON_ERROR | true),
+            'min_max' => json_encode([8, 36], JSON_THROW_ON_ERROR | true),
         ],
         'details' => [
             'prize' => 'Premio de prueba',


### PR DESCRIPTION
## Summary
- enforce group size ranges in `CreateTournamentScheduleRequest`, cap group formats at 36 teams, and reject single-group allocations
- align group-phase tournament configuration defaults with the 36-team ceiling and add a migration to update stored configurations
- adjust test helpers to use the new max teams value and cover validation edge cases for group schedules

## Testing
- `DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test --filter=TournamentScheduleValidationTest`


------
https://chatgpt.com/codex/tasks/task_e_68d04efac3e08329bd4d230d566e0e99