### PR TITLE
Adjust teams to next round calculation for group stage

### DIFF
--- a/tests/Feature/ScheduleGenerationTest.php
+++ b/tests/Feature/ScheduleGenerationTest.php
@@ -329,6 +329,12 @@ it('genera y expone dieciseisavos de final con 32 equipos', function () {
         ]
     );
 
+    $preEliminationSettings = $this->getJson("/api/v1/admin/tournaments/{$t->id}/schedule/settings")
+        ->assertOk()
+        ->json();
+
+    expect($preEliminationSettings['teams_to_next_round'])->toBe(32);
+
     $teamTournamentRows = DB::table('team_tournament')
         ->where('tournament_id', $t->id)
         ->orderBy('team_id')


### PR DESCRIPTION
## Summary
- derive the fallback teams_to_next_round value from group configuration when no knockout phase is active while keeping the existing elimination mapping
- extend the schedule generation feature test to assert the teams_to_next_round value before enabling the knockout stage

## Testing
- `php artisan test --filter=ScheduleGenerationTest` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68d09d4dbcc8832981afd000e33e43ac